### PR TITLE
Add basic mpz support.

### DIFF
--- a/Oleanparser.lean
+++ b/Oleanparser.lean
@@ -50,7 +50,13 @@ def parseObj (objs : Std.HashMap UInt64 Obj) : ByteArrayParser Obj := do
     let utf8 ← readBytes size.toNat
     let utf8 := utf8.extract 0 (utf8.size - 1) -- drop zero terminator
     Obj.string <| String.fromUTF8Unchecked utf8 -- TODO
-  | 250 => error "mpz"
+  | 250 =>
+    let capacity ← read32LE
+    let signSize ← read32LE
+    let limbsPtr ← read64LE
+    -- 8 = sizeof(mp_limb_t) = sizeof(unsigned long int)  (except on Windows? 😱)
+    let limbs ← readBytes (capacity.toNat * 8)
+    Obj.mpz
   | 251 =>
     let value ← read64LE
     let closure ← read64LE

--- a/Oleanparser/Object.lean
+++ b/Oleanparser/Object.lean
@@ -14,7 +14,7 @@ inductive Obj
   | thunk (value : Obj)
   | task (value : Obj)
   | ref (ref : Obj)
-  -- | mpz
+  | mpz  -- TODO: decode
   deriving Inhabited
 
 namespace Obj
@@ -35,6 +35,7 @@ unsafe def countRefsCore (o : Obj) : StateM (RefMap Nat) Unit := do
   | Obj.thunk x => x.countRefsCore
   | Obj.task x => x.countRefsCore
   | Obj.ref x => x.countRefsCore
+  | Obj.mpz .. => ()
 
 unsafe def countRefs (o : Obj) : RefMap Nat :=
   o.countRefsCore.run {} |>.2
@@ -63,6 +64,7 @@ unsafe def reprCore : Obj → ReprM Format
       | Obj.task v => f!"Obj.task{Format.line}{← reprCore v}"
       | Obj.ref r => f!"Obj.ref{Format.line}{← reprCore r}"
       | Obj.sarray bs => f!"Obj.sarray'{Format.line}{bs}"
+      | Obj.mpz .. => f!"<mpz>"
       | Obj.scalar .. => unreachable!
     let res := res.fill.nest 2
     let newDeclId := s!"x{(← get).ids.size + 1}"


### PR DESCRIPTION
This doesn't actually decode the value, and will need to be adjusted when we move on from GMP, but at least we can successfully read `Prelude.olean` with it.